### PR TITLE
Bump version to 1.15.2 and improve templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## v0.9.0 WIP
+## v0.10.0 WIP
 
 ### Changed
 
 - Migrated to be deployed via an app CR not a chartconfig CR.
+
+## [v0.9.0]
+
+### Changed
+
+- Updated cluster-autoscaler to upstream version [1.15.2](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.15.2).
 
 ## v0.8.0 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,44 @@
 [![CircleCI](https://circleci.com/gh/giantswarm/cluster-autoscaler-app.svg?style=shield)](https://circleci.com/gh/giantswarm/cluster-autoscaler-app)
 
 # cluster-autoscaler-app
-Helm Chart for cluster-autoscaler in Tenant Clusters
+
+Helm chart for Kubernetes Cluster Autoscaler running in Tenant Clusters
+
+* Installs the [kubernetes-metrics-server].
+
+## Deployment
+
+* Managed by [app-operator].
+* Production releases are stored in the [default-catalog].
+* WIP releases are stored in the [default-test-catalog].
+
+## Installing the Chart
+
+To install the chart locally:
+
+```bash
+$ git clone https://github.com/giantswarm/cluster-autoscaler-app.git
+$ cd cluster-autoscaler-app
+$ helm install helm/cluster-autoscaler-app
+```
+
+Provide a custom `values.yaml`:
+
+```bash
+$ helm install cluster-autoscaler-app -f values.yaml
+```
+
+ ## Release Process
+
+* Ensure CHANGELOG.md is up to date.
+* Create a new GitHub release with the version e.g. `v0.1.0` and link the
+changelog entry.
+* This will push a new git tag and trigger a new tarball to be pushed to the
+[default-catalog].  
+* Update [cluster-operator] with the new version.
+
+[app-operator]: https://github.com/giantswarm/app-operator
+[cluster-operator]: https://github.com/giantswarm/cluster-operator
+[default-catalog]: https://github.com/giantswarm/default-catalog
+[default-test-catalog]: https://github.com/giantswarm/default-test-catalog
+[kubernetes-cluster-autoscaler]: https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#cluster-autoscaler

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         kubernetes.io/role: master
       priorityClassName: giantswarm-critical
       containers:
-        - image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        - image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
           name: {{ .Values.name }}
           resources:
             limits:

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -17,8 +17,8 @@ configmap:
 
 image:
   registry: quay.io
-  tag: v1.14.3
   name: giantswarm/cluster-autoscaler
+  tag: v1.15.2
 
 cluster:
   id: "test-cluster"

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -17,8 +17,8 @@ configmap:
 
 image:
   registry: quay.io
-  repository: giantswarm/cluster-autoscaler
   tag: v1.14.3
+  name: giantswarm/cluster-autoscaler
 
 cluster:
   id: "test-cluster"


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/kubernetes-cluster-autoscaler/pull/27 to keep project in sync as we'll be migrating to App Catalog soon.