### PR TITLE
Increment version to 1.0.0 for move to default app catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Extend configuration options to allow users to tune the Cluster Autoscaler in deep.
 
+[v1.0.0]: https://github.com/giantswarm/cluster-autoscaler-app/pull/6
 [v0.9.0]: https://github.com/giantswarm/kubernetes-cluster-autoscaler/pull/27
 [v0.8.0]: https://github.com/giantswarm/kubernetes-cluster-autoscaler/pull/26 
 [v0.7.0]: https://github.com/giantswarm/kubernetes-cluster-autoscaler/pull/24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## v0.10.0
+## [v1.0.0]
 
 ### Changed
 
@@ -52,6 +52,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Extend configuration options to allow users to tune the Cluster Autoscaler in deep.
 
+[v0.9.0]: https://github.com/giantswarm/kubernetes-cluster-autoscaler/pull/27
+[v0.8.0]: https://github.com/giantswarm/kubernetes-cluster-autoscaler/pull/26 
 [v0.7.0]: https://github.com/giantswarm/kubernetes-cluster-autoscaler/pull/24
 [v0.6.0]: https://github.com/giantswarm/kubernetes-cluster-autoscaler/pull/23
 [v0.5.0]: https://github.com/giantswarm/kubernetes-cluster-autoscaler/pull/22


### PR DESCRIPTION
We agreed in @giantswarm/team-batman that the apps being moved to the default app catalog would be 1.x. Since they are fully supported.