### PR TITLE
Fix clusterID value

### DIFF
--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - --cloud-provider=aws
             - --expander={{ .Values.configmap.expander }}
             - --logtostderr=true
-            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .Values.cluster.id }}
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .Values.clusterID }}
             - --skip-nodes-with-local-storage={{ .Values.configmap.skipNodesWithLocalStorage }}
             - --skip-nodes-with-system-pods={{ .Values.configmap.skipNodesWithSystemPods }}
             - --scale-down-utilization-threshold={{ .Values.configmap.scaleDownUtilizationThreshold }}

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -20,5 +20,5 @@ image:
   name: giantswarm/cluster-autoscaler
   tag: v1.15.2
 
-cluster:
-  id: "test-cluster"
+clusterID:
+  "test-cluster"


### PR DESCRIPTION
ClusterID is coming from helm chart values, `Values.cluster.id`. But from release 10.0.0, it changed to the way from `Values.clusterID`. 

slack: https://gigantic.slack.com/archives/C2MS2VB37/p1573134620015200