### PR TITLE
Prepare deployment to support Azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Updated cluster-autoscaler to upstream version [1.16.2](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.2).
+- Updated deployment to support Azure autodiscover.
 
 ## [v1.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Updated cluster-autoscaler to upstream version [1.16.2](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.2).
-- Updated deployment to support Azure autodiscover.
+
+### Added
+
+- Added support for Azure with auto-discovery.
 
 ## [v1.0.0]
 

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -44,15 +44,10 @@ spec:
             - --cloud-provider={{ .Values.provider }}
             - --logtostderr=true
             - --stderrthreshold=info
-            {{- if eq .Values.provider "azure" }}
-            {{- if .Values.autoscalingGroups }}
-            {{- range .Values.autoscalingGroups }}
-            - --nodes={{ printf "%s:%s:%s-%s" .minSize .maxSize $.Values.clusterID "worker" }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
             {{- if eq .Values.provider "aws" }}
-            - --node-group-auto-discovery=asg:tag={{ tpl (join "," .Values.autoDiscovery.tags) . }}
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .Values.clusterID }}
+            {{- else if eq .Values.provider "azure" }}
+            - --node-group-auto-discovery=label:cluster-autoscaler-enabled=true,cluster-autoscaler-name={{ .Values.clusterID }}
             {{- end }}
             {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -42,16 +42,18 @@ spec:
             - ./cluster-autoscaler
             - --v=4
             - --cloud-provider={{ .Values.provider }}
+            - --expander={{ .Values.configmap.expander }}
             - --logtostderr=true
-            - --stderrthreshold=info
             {{- if eq .Values.provider "aws" }}
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .Values.clusterID }}
             {{- else if eq .Values.provider "azure" }}
             - --node-group-auto-discovery=label:cluster-autoscaler-enabled=true,cluster-autoscaler-name={{ .Values.clusterID }}
             {{- end }}
-            {{- range $key, $value := .Values.extraArgs }}
-            - --{{ $key }}={{ $value }}
-            {{- end }}
+            - --skip-nodes-with-local-storage={{ .Values.configmap.skipNodesWithLocalStorage }}
+            - --skip-nodes-with-system-pods={{ .Values.configmap.skipNodesWithSystemPods }}
+            - --scale-down-utilization-threshold={{ .Values.configmap.scaleDownUtilizationThreshold }}
+            - --scan-interval={{ .Values.configmap.scanInterval }}
+            - --stderrthreshold=info
 
           env:
             {{- if eq .Values.provider "azure" }}

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -56,13 +56,13 @@ spec:
           env:
             {{- if eq .Values.provider "azure" }}
             - name: ARM_SUBSCRIPTION_ID
-              value: {{ .Values.subscriptionID }}
+              value: {{ .Values.azure.subscriptionID }}
             - name: ARM_RESOURCE_GROUP
               value: {{ .Values.clusterID }}
             - name: ARM_USE_MANAGED_IDENTITY_EXTENSION
-              value: {{ quote .Values.managedIdentity }}
+              value: {{ quote .Values.azure.managedIdentity }}
             - name: ARM_VM_TYPE
-              value: {{ .Values.azureVMType }}
+              value: {{ .Values.azure.vmType }}
             {{- end }}
 
           volumeMounts:

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -41,15 +41,17 @@ spec:
           command:
             - ./cluster-autoscaler
             - --v=4
-            - --cloud-provider=aws
+            - --cloud-provider={{ .Values.configmap.provider }}
             - --expander={{ .Values.configmap.expander }}
             - --logtostderr=true
-            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .Values.clusterID }}
-            - --skip-nodes-with-local-storage={{ .Values.configmap.skipNodesWithLocalStorage }}
-            - --skip-nodes-with-system-pods={{ .Values.configmap.skipNodesWithSystemPods }}
-            - --scale-down-utilization-threshold={{ .Values.configmap.scaleDownUtilizationThreshold }}
-            - --scan-interval={{ .Values.configmap.scanInterval }}
             - --stderrthreshold=info
+            {{- if eq .Values.configmap.provider "aws" }}
+            - --node-group-auto-discovery=asg:tag={{ tpl (join "," .Values.configmap.autoDiscovery.tags) . }}
+            {{- end }}
+            {{- range $key, $value := .Values.configmap.extraArgs }}
+            - --{{ $key }}={{ $value }}
+            {{- end }}
+
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs/ca-certificates.crt

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -41,15 +41,33 @@ spec:
           command:
             - ./cluster-autoscaler
             - --v=4
-            - --cloud-provider={{ .Values.configmap.provider }}
-            - --expander={{ .Values.configmap.expander }}
+            - --cloud-provider={{ .Values.provider }}
             - --logtostderr=true
             - --stderrthreshold=info
-            {{- if eq .Values.configmap.provider "aws" }}
-            - --node-group-auto-discovery=asg:tag={{ tpl (join "," .Values.configmap.autoDiscovery.tags) . }}
+            {{- if eq .Values.provider "azure" }}
+            {{- if .Values.autoscalingGroups }}
+            {{- range .Values.autoscalingGroups }}
+            - --nodes={{ printf "%s:%s:%s-%s" .minSize .maxSize $.Values.clusterID "worker" }}
             {{- end }}
-            {{- range $key, $value := .Values.configmap.extraArgs }}
+            {{- end }}
+            {{- end }}
+            {{- if eq .Values.provider "aws" }}
+            - --node-group-auto-discovery=asg:tag={{ tpl (join "," .Values.autoDiscovery.tags) . }}
+            {{- end }}
+            {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
+            {{- end }}
+
+          env:
+            {{- if eq .Values.provider "azure" }}
+            - name: ARM_SUBSCRIPTION_ID
+              value: {{ .Values.subscriptionID }}
+            - name: ARM_RESOURCE_GROUP
+              value: {{ .Values.clusterID }}
+            - name: ARM_USE_MANAGED_IDENTITY_EXTENSION
+              value: {{ quote .Values.managedIdentity }}
+            - name: ARM_VM_TYPE
+              value: {{ .Values.azureVMType }}
             {{- end }}
 
           volumeMounts:

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -8,13 +8,6 @@ groupID: 65534
 port: 8085
 
 # Make sure to update the docs at https://github.com/giantswarm/docs/blob/master/src/layouts/shortcodes/autoscaler_utilization_threshold.html if you change the defaults below
-configmap:
-  expander: "least-waste"
-  scanInterval: "10s"
-  scaleDownUtilizationThreshold: 0.65
-  skipNodesWithLocalStorage: "false"
-  skipNodesWithSystemPods: "true"
-
 image:
   registry: quay.io
   name: giantswarm/cluster-autoscaler
@@ -22,3 +15,20 @@ image:
 
 clusterID:
   "test-cluster"
+
+extraArgs:
+  scan-interval: 10s
+  scale-down-utilization-threshold: 0.65
+  skip-nodes-with-system-pods: true
+  skip-nodes-with-local-storage: false
+  expander: least-waste
+  # write-status-configmap: true
+  # leader-elect: true
+  # scale-down-enabled: true
+  # balance-similar-node-groups: true
+  # min-replica-count: 2
+  # scale-down-non-empty-candidates-count: 5
+  # max-node-provision-time: 15m0s
+  # scale-down-delay: 10m
+  # scale-down-unneeded-time: 10m
+

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -13,9 +13,14 @@ image:
   name: giantswarm/cluster-autoscaler
   tag: v1.15.2
 
-clusterID:
-  "test-cluster"
+clusterID: "test-cluster"
 provider: "changeme"
+
+azure:
+  subscriptionID: "changeme"
+  managedIdentity: true
+  vmType: VMSS
+
 extraArgs:
   scan-interval: 10s
   scale-down-utilization-threshold: 0.65

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -18,7 +18,7 @@ image:
 clusterID: "test-cluster"
 # provider is dynamic environment value, which comes from application catalog configuration
 # applies only to Giant Swarm clusters
-provider: "changeme"
+provider: "aws"
 # azure contains the configuration values required by the azure provider and can be overridden
 # with custom values
 azure:

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -8,6 +8,13 @@ groupID: 65534
 port: 8085
 
 # Make sure to update the docs at https://github.com/giantswarm/docs/blob/master/src/layouts/shortcodes/autoscaler_utilization_threshold.html if you change the defaults below
+configmap:
+  expander: "least-waste"
+  scanInterval: "10s"
+  scaleDownUtilizationThreshold: 0.65
+  skipNodesWithLocalStorage: "false"
+  skipNodesWithSystemPods: "true"
+
 image:
   registry: quay.io
   name: giantswarm/cluster-autoscaler
@@ -29,11 +36,4 @@ azure:
   # Type of deployment used on Azure
   vmType: VMSS
 
-# Command line arguments passed to the cluster-autoscaler process
-extraArgs:
-  scan-interval: 10s
-  scale-down-utilization-threshold: 0.65
-  skip-nodes-with-system-pods: true
-  skip-nodes-with-local-storage: false
-  expander: least-waste
 

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -13,27 +13,27 @@ image:
   name: giantswarm/cluster-autoscaler
   tag: v1.15.2
 
+# clusterID is dynamic environment value, calculated after cluster creation
+# applies only to Giant Swarm clusters
 clusterID: "test-cluster"
+# provider is dynamic environment value, which comes from application catalog configuration
+# applies only to Giant Swarm clusters
 provider: "changeme"
-
+# azure contains the configuration values required by the azure provider and can be overridden
+# with custom values
 azure:
+  # Azure subscription where the VMSS are created
   subscriptionID: "changeme"
+  # Whether or not to use the credentials automatically provisioned on the VMSS instances
   managedIdentity: true
+  # Type of deployment used on Azure
   vmType: VMSS
 
+# Command line arguments passed to the cluster-autoscaler process
 extraArgs:
   scan-interval: 10s
   scale-down-utilization-threshold: 0.65
   skip-nodes-with-system-pods: true
   skip-nodes-with-local-storage: false
   expander: least-waste
-  # write-status-configmap: true
-  # leader-elect: true
-  # scale-down-enabled: true
-  # balance-similar-node-groups: true
-  # min-replica-count: 2
-  # scale-down-non-empty-candidates-count: 5
-  # max-node-provision-time: 15m0s
-  # scale-down-delay: 10m
-  # scale-down-unneeded-time: 10m
 

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -15,7 +15,7 @@ image:
 
 clusterID:
   "test-cluster"
-
+provider: "changeme"
 extraArgs:
   scan-interval: 10s
   scale-down-utilization-threshold: 0.65


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5804

Instead of hardcoding the cli arguments, I moved some of the configuration values to command line arguments to be passed to the cluster-autoscaler cli.

I also added the required logic to make it work on both aws and azure. The changes needed on cluster-autoscaler to make auto-discovery of VMSS work on azure are already merged. They will most likely be released when Kubernetes 1.17 is released (they make releases of cluster-autoscaler together with Kubernetes) on December.