### PR TITLE
Use upstream autoscaler version 1.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.0.1]
+
+### Changed
+
+- Updated cluster-autoscaler to upstream version [1.16.2](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.2).
+
 ## [v1.0.0]
 
 ### Changed
@@ -17,7 +23,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Updated cluster-autoscaler to upstream version [1.15.2](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.15.2).
 
-## v0.8.0 
+## [v0.8.0] 
 
 ### Changed
 

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -18,7 +18,7 @@ configmap:
 image:
   registry: quay.io
   name: giantswarm/cluster-autoscaler
-  tag: v1.15.2
+  tag: v1.16.2
 
 clusterID:
   "test-cluster"


### PR DESCRIPTION
Update autoscaler image to 1.16.2 (from 1.15.2) towards https://github.com/giantswarm/giantswarm/issues/7428

No breaking changes listed in upstream release notes