### PR TITLE
Disable e2e tests for master and adjust test timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.4.3
+  architect: giantswarm/architect@0.4.5
 
 e2eTest: &e2eTest
   machine: true
@@ -86,12 +86,8 @@ workflows:
     jobs:
       - build
 
-      - e2eTestBasic:
-          requires:
-            - build
-
       - architect/push-to-app-catalog:
-          name: "package and push cluster-autoscaler-app chart"
+          name: push-to-default-app-catalog
           app_catalog: "default-catalog"
           app_catalog_test: "default-test-catalog"
           chart: "cluster-autoscaler-app"
@@ -99,3 +95,12 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+
+      - e2eTestBasic:
+          requires:
+            - build
+            - push-to-default-app-catalog
+          filters:
+            branches:
+              ignore:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ e2eTest: &e2eTest
             -e E2E_KUBECONFIG=/e2e/kubeconfig \
             -e CIRCLE_SHA1=${CIRCLE_SHA1} \
             -w /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} \
-            golang:1 go test -v -tags k8srequired ./${E2E_TEST_DIR}/
+            golang:1 go test -timeout 20m -v -tags k8srequired ./${E2E_TEST_DIR}/
     - run:
         name: Export logs
         command: |


### PR DESCRIPTION
Same issue as with giantswarm/node-exporter-app#8 & giantswarm/metrics-server-app#10, master branch e2e tests are failing https://circleci.com/gh/giantswarm/cluster-autoscaler-app/152 due to invalid use of default-test-catalog for all builds https://github.com/giantswarm/cluster-autoscaler-app/blob/master/.circleci/config.yml#L43

This PR works around the issue by disabling e2e tests for master branch.

Also, similar to app-operator e2e tests (see recent [fix](https://github.com/giantswarm/app-operator/pull/181)), cluster-autoscaler-app e2e tests seem to take longer than `go test` default of 10min (see failed build [here](https://circleci.com/gh/giantswarm/cluster-autoscaler-app/156)). This PR adjusts that timeout to 20min.

Issues were uncovered while working on giantswarm/giantswarm#6817