### PR TITLE
increase-mem-limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.1.4] 2020-01-24
+
+- Increase memory request and limits to 400MB.
+
 ## [v1.1.3] 2020-01-22
 
 ### Changed

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -33,10 +33,10 @@ spec:
           name: {{ .Values.name }}
           resources:
             limits:
-              memory: 300Mi
+              memory: 400Mi
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 400Mi
           command:
             - ./cluster-autoscaler
             - --v=4


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/7280

increasing memory limits and requests to 400mb, on large clusters (100 nodes+) this was an issue.

I was thinking about using addon resizer but since we run the cluster-autoscale in master node this is dangerous.

We need to be sure that the resources on the master are always available, we could get into a scenario that on start autoscaler would be scheduled but then the limits would be increased and it would no longer be able to fit into master. SO having statically set requests and limits seems better. 