### PR TITLE
lower scale-down-utilization-threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.1.5] 2020-04-14
+
+### Changed
+
+- Lower `scaleDownUtilizationThreshold` to 0.5.
+
 ## [v1.1.4] 2020-02-05
 
 - Increase memory request and limits to 400MB.
@@ -84,6 +90,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Extend configuration options to allow users to tune the Cluster Autoscaler in deep.
 
+[v1.1.5]: https://github.com/giantswarm/cluster-autoscaler-app/pull/20
 [v1.1.4]: https://github.com/giantswarm/cluster-autoscaler-app/pull/17
 [v1.1.3]: https://github.com/giantswarm/cluster-autoscaler-app/pull/14
 [v1.1.2]: https://github.com/giantswarm/cluster-autoscaler-app/pull/13

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -11,7 +11,7 @@ port: 8085
 configmap:
   expander: "least-waste"
   scanInterval: "10s"
-  scaleDownUtilizationThreshold: 0.65
+  scaleDownUtilizationThreshold: 0.5
   skipNodesWithLocalStorage: "false"
   skipNodesWithSystemPods: "true"
 


### PR DESCRIPTION
I think it makes sense to lower the default scale-down-utilization-threshold to 0.5 since that is the upstream default and a lower value here can help with issues like these: https://github.com/giantswarm/giantswarm/issues/9593