### PR TITLE
Set upstream version to 1.16.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Set `scan-interval` to 30 seconds (from 10 seconds) to save resources.
+- Set `scale-down-unneeded-time` to 5 minutes (from the default of 10 minutes) to release unneeded nodes earlier.
+
 ## [v1.1.5] 2020-04-14
 
 ### Changed

--- a/helm/cluster-autoscaler-app/Chart.yaml
+++ b/helm/cluster-autoscaler-app/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+appVersion: v1.16.5
 description: A Helm chart for the cluster autoscaler.
 name: cluster-autoscaler-app
 version: [[ .Version ]]

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -45,6 +45,7 @@ spec:
             - --logtostderr=true
             {{- if eq .Values.provider "aws" }}
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .Values.clusterID }}
+            - --aws-use-static-instance-list=true
             {{- else if eq .Values.provider "azure" }}
             - --node-group-auto-discovery=label:cluster-autoscaler-enabled=true,cluster-autoscaler-name={{ .Values.clusterID }}
             {{- end }}

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
             - --logtostderr=true
             {{- if eq .Values.provider "aws" }}
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .Values.clusterID }}
+            # Turning runtime instance info acquisition off because of
+            # https://github.com/kubernetes/autoscaler/issues/3076
             - --aws-use-static-instance-list=true
             {{- else if eq .Values.provider "azure" }}
             - --node-group-auto-discovery=label:cluster-autoscaler-enabled=true,cluster-autoscaler-name={{ .Values.clusterID }}

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -18,7 +18,7 @@ configmap:
 image:
   registry: quay.io
   name: giantswarm/cluster-autoscaler
-  tag: v1.16.2
+  tag: v1.16.5
 
 # clusterID is dynamic environment value, calculated after cluster creation
 # applies only to Giant Swarm clusters


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11112

This updates the upstream version to 1.16.5, which is the latest in 1.16.

---

I found that the cluster-autoscaler version has a new feature where it tries to load the EC2 instance information from an AWS API, and that [does not work in China](https://github.com/kubernetes/autoscaler/issues/3076).

So we also add the `--aws-use-static-instance-list=true` flag to turn off the dynamic loading.