### PR TITLE
Modify defaults for scan-interval, scale-down-unneeded-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Set `scan-interval` to 30 seconds (from 10 seconds) to save resources.
+- Set `scale-down-unneeded-time` to 5 minutes (from the default of 10 minutes) to release unneeded nodes earlier.
+
 ## [v1.1.5] 2020-04-14
 
 ### Changed

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
             {{- end }}
             - --skip-nodes-with-local-storage={{ .Values.configmap.skipNodesWithLocalStorage }}
             - --skip-nodes-with-system-pods={{ .Values.configmap.skipNodesWithSystemPods }}
+            - --scale-down-unneeded-time={{ .Values.configmap.scaleDownUnneededTime }}
             - --scale-down-utilization-threshold={{ .Values.configmap.scaleDownUtilizationThreshold }}
             - --scan-interval={{ .Values.configmap.scanInterval }}
             - --stderrthreshold=info

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -10,8 +10,8 @@ port: 8085
 # Make sure to update the docs at https://github.com/giantswarm/docs/blob/master/src/layouts/shortcodes/autoscaler_utilization_threshold.html if you change the defaults below
 configmap:
   expander: "least-waste"
-  scaleDownUnneededTime: 10m0s
   scanInterval: 30s
+  scaleDownUnneededTime: 5m0s
   scaleDownUtilizationThreshold: 0.5
   skipNodesWithLocalStorage: "false"
   skipNodesWithSystemPods: "true"

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -10,8 +10,8 @@ port: 8085
 # Make sure to update the docs at https://github.com/giantswarm/docs/blob/master/src/layouts/shortcodes/autoscaler_utilization_threshold.html if you change the defaults below
 configmap:
   expander: "least-waste"
-  scanInterval: "10s"
   scaleDownUnneededTime: 10m0s
+  scanInterval: 30s
   scaleDownUtilizationThreshold: 0.5
   skipNodesWithLocalStorage: "false"
   skipNodesWithSystemPods: "true"

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -9,7 +9,7 @@ port: 8085
 
 # Make sure to update the docs at https://github.com/giantswarm/docs/blob/master/src/layouts/shortcodes/autoscaler_utilization_threshold.html if you change the defaults below
 configmap:
-  expander: "least-waste"
+  expander: least-waste
   scanInterval: 30s
   scaleDownUnneededTime: 5m0s
   scaleDownUtilizationThreshold: 0.5

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -11,6 +11,7 @@ port: 8085
 configmap:
   expander: "least-waste"
   scanInterval: "10s"
+  scaleDownUnneededTime: 10m0s
   scaleDownUtilizationThreshold: 0.5
   skipNodesWithLocalStorage: "false"
   skipNodesWithSystemPods: "true"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11157, https://github.com/giantswarm/giantswarm/issues/11133

Changes

- Increase scan interval from 10 to 30 seconds
- Release unneeded nodes after 5 instead of 10 minutes