### PR TITLE
Prepare changelog for release v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [v1.16.0](https://github.com/giantswarm/cluster-autoscaler-app/compare/v1.1.4...v1.16.0) 2020-05-26
+
+Note that with this release we start to align the versioning scheme to the upstream project, so our v1.16.x represents upstream v1.16.x.
 
 ### Changed
 
+- Use cluster-autoscaler version v1.16.5.
+  - This version introduces a new method to read AWS EC2 instance type details from an AWS API. Since this API is not reachable from the AWS China regions, the autoscaler is started with the `--aws-use-static-instance-list=true` flag.
 - Set `scan-interval` to 30 seconds (from 10 seconds) to save resources.
 - Set `scale-down-unneeded-time` to 5 minutes (from the default of 10 minutes) to release unneeded nodes earlier.
-
-## [v1.1.5] 2020-04-14
-
-### Changed
-
 - Lower `scaleDownUtilizationThreshold` to 0.5.
 
 ## [v1.1.4] 2020-02-05
+
+### Changed
 
 - Increase memory request and limits to 400MB.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 # cluster-autoscaler-app
 
-Helm chart for Kubernetes Cluster Autoscaler running in Tenant Clusters
-
-* Installs the [kubernetes-cluster-autoscaler].
+Helm chart for the Kubernetes [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) running in Giant Swarm tenant clusters.
 
 ## Deployment
 
@@ -16,29 +14,29 @@ Helm chart for Kubernetes Cluster Autoscaler running in Tenant Clusters
 
 To install the chart locally:
 
-```bash
-$ git clone https://github.com/giantswarm/cluster-autoscaler-app.git
-$ cd cluster-autoscaler-app
-$ helm install helm/cluster-autoscaler-app
+```nohighlight
+git clone https://github.com/giantswarm/cluster-autoscaler-app.git
+cd cluster-autoscaler-app
+helm install helm/cluster-autoscaler-app
 ```
 
 Provide a custom `values.yaml`:
 
-```bash
-$ helm install cluster-autoscaler-app -f values.yaml
+```nohighlight
+helm install cluster-autoscaler-app -f values.yaml
 ```
 
- ## Release Process
+## Release Process
 
 * Ensure CHANGELOG.md is up to date.
-* Create a new GitHub release with the version e.g. `v0.1.0` and link the
+* Create a new GitHub release with the version e.g. `v1.16.1` and link the
 changelog entry.
+  * Make sure the Major and Minor versions match with the upstream version.
 * This will push a new git tag and trigger a new tarball to be pushed to the
-[default-catalog].  
+[default-catalog].
 * Update [cluster-operator] with the new version.
 
 [app-operator]: https://github.com/giantswarm/app-operator
 [cluster-operator]: https://github.com/giantswarm/cluster-operator
 [default-catalog]: https://github.com/giantswarm/default-catalog
 [default-test-catalog]: https://github.com/giantswarm/default-test-catalog
-[kubernetes-cluster-autoscaler]: https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#cluster-autoscaler


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11112

- Added all change info to the latest changelog entry
- Removed the v1.1.5 part in the changelog, as that never got released
- Cleaned up the README a bit