### PR TITLE
Don't set the subscription ID env variable if empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 - Added monitoring annotations and common labels.
 
+### Changed
+- The `ARM_SUBSCRIPTION_ID` env variable is not set when the customer is not giving it a value. The `cluster-autoscaler` detects the value from the VM it is running on.
+
 ## [1.17.3] - 2020-07-30
 
 ### Updated

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -60,8 +60,10 @@ spec:
             - --stderrthreshold=info
           {{- if eq .Values.provider "azure" }}
           env:
+            {{- if ne .Values.azure.subscriptionID "" }}
             - name: ARM_SUBSCRIPTION_ID
               value: {{ .Values.azure.subscriptionID }}
+            {{- end }}
             - name: ARM_RESOURCE_GROUP
               value: {{ .Values.clusterID }}
             - name: ARM_USE_MANAGED_IDENTITY_EXTENSION

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -33,7 +33,7 @@ provider: "aws"
 # with custom values
 azure:
   # Azure subscription where the VMSS are created
-  subscriptionID: "changeme"
+  subscriptionID: ""
   # Whether or not to use the credentials automatically provisioned on the VMSS instances
   managedIdentity: true
   # Type of deployment used on Azure


### PR DESCRIPTION
According to https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/azure#deployment-manifests 


> The subscriptionID parameter is optional. When skipped, the subscription will be fetched from the instance metadata.

This PR avoids setting that environment variable when it's not overridden by the customer using a custom values.yaml
