### PR TITLE
Revert "Updated cluster-autoscaler to version `1.18.2`."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-### Changed
-
-- Updated cluster-autoscaler to version `1.18.2`.
-
 ## [1.17.4] - 2020-09-14
 
 ### Added

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -21,7 +21,7 @@ e2e: false
 image:
   registry: quay.io
   name: giantswarm/cluster-autoscaler
-  tag: v1.18.2
+  tag: v1.17.3
 
 # clusterID is dynamic environment value, calculated after cluster creation
 # applies only to Giant Swarm clusters


### PR DESCRIPTION
Reverts giantswarm/cluster-autoscaler-app#44