### PR TITLE
Use new node selector `node-role.kubernetes.io/master` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use new node selector `node-role.kubernetes.io/master` in place of deprecated one `kubernetes.io/role`.
+
 ## [1.22.0] - 2021-07-28
 
 ### Changed

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         operator: "Exists"
         key: node-role.kubernetes.io/master
       nodeSelector:
-        kubernetes.io/role: master
+        node-role.kubernetes.io/master: ""
       priorityClassName: giantswarm-critical
       containers:
         {{- if eq .Values.isManagementCluster true }}


### PR DESCRIPTION
CAPI clusters and our clusters as well ([See code](https://github.com/giantswarm/k8scloudconfig/blob/master/pkg/template/master_template.go#L370)) use `node-role.kubernetes.io/master`  label for master nodes.

This app used to have a nodeselector on the deprecated label `kubernetes.io/role: master` making the pod unschedulable on CAPI clusters.

This PR addresses this problem by switching to the new label.