### PR TITLE
Increase memory limit to avoid OOMs when starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Increase memory limit to avoid OOM's when starting.
+
 ## [1.21.0-gs2] - 2021-09-29
 
 - Fix RBAC for cluster autoscaler 1.21.

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -45,7 +45,7 @@ azure:
 
 clusterAutoscalerResources:
   limits:
-    memory: 400Mi
+    memory: 800Mi
   requests:
     cpu: 100m
     memory: 400Mi


### PR DESCRIPTION
Addresses https://github.com/giantswarm/giantswarm/issues/18980
This was detected in a fresh new installation.

This is basically only when starting cluster-autoscaler. After it's running fine the VPA will anyway adjust the settings. It's only to avoid crashlooping in the beginning, this will also solve manual interaction. VPA needs to have running pods before it's able to adjust resources of ca.