### PR TITLE
Use GS-built 1.22 image to deliver upstream unreleased fix https://gi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Fixed
 
 - Updated to correct cluster-autoscaler version
+- Use GS-built 1.22 image to deliver upstream unreleased fix https://github.com/kubernetes/autoscaler/pull/4600
 
 ## [1.22.2-gs3] - 2022-02-07
 

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -26,7 +26,7 @@ managementCluster:
 image:
   registry: docker.io
   name: giantswarm/cluster-autoscaler
-  tag: v1.22.2
+  tag: v1.22.2-gsfix
 
 # clusterID is dynamic environment value, calculated after cluster creation
 # applies only to Giant Swarm clusters


### PR DESCRIPTION
…thub.com/kubernetes/autoscaler/pull/4600

Towards: https://github.com/giantswarm/roadmap/issues/784

since upstream didn't release our fix to branch 1.22 we built our own image.

This PR makes use of that manually pushed image.