### PR TITLE
Add 'projected' volumes to the PSP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add 'projected' volumes to the PSP.
+
 ## [1.24.0-gs1] - 2022-09-21
 
 ### Changed

--- a/helm/cluster-autoscaler-app/templates/psp.yaml
+++ b/helm/cluster-autoscaler-app/templates/psp.yaml
@@ -23,6 +23,7 @@ spec:
   volumes:
   - 'secret'
   - 'hostPath'
+  - 'projected'
   hostPID: false
   hostIPC: false
   hostNetwork: false


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26239

aws-pod-identity-webhook injects projected volumes to pods and this makes cluster autoscaler unschedulable at times