### PR TITLE
- Disable PSPs for k8s 1.25 and newer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add 'projected' volumes to the PSP.
 - Add new-pod-scale-up-delay variable.
+- Disable PSPs for k8s 1.25 and newer.
 
 ## [1.24.0-gs1] - 2022-09-21
 

--- a/helm/cluster-autoscaler-app/templates/psp.yaml
+++ b/helm/cluster-autoscaler-app/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -33,3 +34,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}


### PR DESCRIPTION
in k8s 1.25 there is no PodSecurityPolicy

this PR disables the PSP for 1.25