### PR TITLE
Use new control-plane label

### DIFF
--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -24,7 +24,11 @@ spec:
         operator: "Exists"
         key: node-role.kubernetes.io/master
       nodeSelector:
+{{- if semverCompare ">=1.24.0" .Capabilities.KubeVersion.Version }}
+        node-role.kubernetes.io/control-plane: ""
+{{- else }}
         node-role.kubernetes.io/master: ""
+{{- end }}
       priorityClassName: giantswarm-critical
       containers:
         {{- if eq .Values.isManagementCluster true }}


### PR DESCRIPTION
This PR uses the old or new control-plane label in the `nodeSelector`, depending on the Kubernetes version used.

Tested by deploying on a WC with Kubernetes version `1.24.11`, as well as, `1.23.17`. 