### PR TITLE
IRSA for cluster-autoscaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add service account annotations as value.
+
 ## [1.27.3-gs2] - 2023-11-03
 
 ### Changed

--- a/helm/cluster-autoscaler-app/templates/service-account.yaml
+++ b/helm/cluster-autoscaler-app/templates/service-account.yaml
@@ -5,3 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/helm/cluster-autoscaler-app/values.schema.json
+++ b/helm/cluster-autoscaler-app/values.schema.json
@@ -142,6 +142,14 @@
                 }
             }
         },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                }
+            }
+        },
         "serviceType": {
             "type": "string"
         },

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -65,3 +65,7 @@ balancingIgnoreLabels:
 global:
   podSecurityStandards:
     enforced: false
+
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}


### PR DESCRIPTION
This change allows to inherit IRSA annotation from default-apps-aws for cluster-autoscaler.
The goal is to minimize the permissions on the node instance profile and moving on with IRSA for our components.