### PR TITLE
Allow to configure ssl cert paths and nodeselector through helm values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add configurable `node.nodeSelector` in values
+
 ### Changed
 
 - Change ScaleDownUtilizationThreshold default from 0.5 to 0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Add configurable `node.nodeSelector` in values
+- Add configurable `node.caBundlePath` in values
 
 ### Changed
 

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -110,4 +110,8 @@ spec:
       volumes:
         - name: ssl-certs
           hostPath:
+            {{- if and .Values.node .Values.node.caBundlePath }}
+            path: "{{ .Values.node.caBundlePath }}"
+            {{- else }}
             path: "/etc/ssl/certs/ca-certificates.crt"
+            {{- end }}

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -23,14 +23,14 @@ spec:
       - effect: NoSchedule
         operator: "Exists"
         key: node-role.kubernetes.io/master
+      {{- if ((.Values.node).nodeSelector) }}
       nodeSelector:
-        {{- if ((.Values.node).nodeSelector) }}
-        {{- toYaml .Values.node.nodeSelector | nindent 8 }}
-        {{- else if semverCompare ">=1.24.0" .Capabilities.KubeVersion.Version }}
-        node-role.kubernetes.io/control-plane: ""
+        {{- if and (hasKey .Values.node.nodeSelector "node-role.kubernetes.io/control-plane") (semverCompare "<1.24.0" .Capabilities.KubeVersion.Version) }}
+        {{- toYaml (set (unset .Values.node.nodeSelector "node-role.kubernetes.io/control-plane") "node-role.kubernetes.io/master" "" )| nindent 8 }}
         {{- else }}
-        node-role.kubernetes.io/master: ""
+        {{- toYaml .Values.node.nodeSelector | nindent 8 }}
         {{- end }}
+      {{- end }}
       priorityClassName: giantswarm-critical
       containers:
         {{- if eq .Values.isManagementCluster true }}

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         operator: "Exists"
         key: node-role.kubernetes.io/master
       nodeSelector:
-{{- if and .Values.node .Values.node.nodeSelector }}
+{{- if ((.Values.node).nodeSelector) }}
         {{- with .Values.node.nodeSelector }}
 {{ toYaml . | indent 8 }}
         {{- end }}
@@ -110,7 +110,7 @@ spec:
       volumes:
         - name: ssl-certs
           hostPath:
-            {{- if and .Values.node .Values.node.caBundlePath }}
+            {{- if ((.Values.node).caBundlePath) }}
             path: "{{ .Values.node.caBundlePath }}"
             {{- else }}
             path: "/etc/ssl/certs/ca-certificates.crt"

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -24,13 +24,11 @@ spec:
         operator: "Exists"
         key: node-role.kubernetes.io/master
       nodeSelector:
-{{- if ((.Values.node).nodeSelector) }}
-        {{- with .Values.node.nodeSelector }}
-{{ toYaml . | indent 8 }}
-        {{- end }}
-{{- else if semverCompare ">=1.24.0" .Capabilities.KubeVersion.Version }}
+        {{- if ((.Values.node).nodeSelector) }}
+        {{- toYaml .Values.node.nodeSelector | nindent 8 }}
+        {{- else if semverCompare ">=1.24.0" .Capabilities.KubeVersion.Version }}
         node-role.kubernetes.io/control-plane: ""
-{{- else }}
+        {{- else }}
         node-role.kubernetes.io/master: ""
 {{- end }}
       priorityClassName: giantswarm-critical

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -24,7 +24,11 @@ spec:
         operator: "Exists"
         key: node-role.kubernetes.io/master
       nodeSelector:
-{{- if semverCompare ">=1.24.0" .Capabilities.KubeVersion.Version }}
+{{- if and .Values.node .Values.node.nodeSelector }}
+        {{- with .Values.node.nodeSelector }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+{{- else if semverCompare ">=1.24.0" .Capabilities.KubeVersion.Version }}
         node-role.kubernetes.io/control-plane: ""
 {{- else }}
         node-role.kubernetes.io/master: ""

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         node-role.kubernetes.io/control-plane: ""
         {{- else }}
         node-role.kubernetes.io/master: ""
-{{- end }}
+        {{- end }}
       priorityClassName: giantswarm-critical
       containers:
         {{- if eq .Values.isManagementCluster true }}

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       {{- if ((.Values.node).nodeSelector) }}
       nodeSelector:
         {{- if and (hasKey .Values.node.nodeSelector "node-role.kubernetes.io/control-plane") (semverCompare "<1.24.0" .Capabilities.KubeVersion.Version) }}
-        {{- toYaml (set (unset .Values.node.nodeSelector "node-role.kubernetes.io/control-plane") "node-role.kubernetes.io/master" "" )| nindent 8 }}
+        {{- toYaml (set (unset .Values.node.nodeSelector "node-role.kubernetes.io/control-plane") "node-role.kubernetes.io/master" "" ) | nindent 8 }}
         {{- else }}
         {{- toYaml .Values.node.nodeSelector | nindent 8 }}
         {{- end }}
@@ -108,8 +108,4 @@ spec:
       volumes:
         - name: ssl-certs
           hostPath:
-            {{- if ((.Values.node).caBundlePath) }}
-            path: "{{ .Values.node.caBundlePath }}"
-            {{- else }}
-            path: "/etc/ssl/certs/ca-certificates.crt"
-            {{- end }}
+            path: {{ .Values.node.caBundlePath }}

--- a/helm/cluster-autoscaler-app/values.schema.json
+++ b/helm/cluster-autoscaler-app/values.schema.json
@@ -138,6 +138,9 @@
             "properties": {
                 "nodeSelector": {
                     "type": "object"
+                },
+                "caBundlePath": {
+                    "type": "string"
                 }
             }
         },

--- a/helm/cluster-autoscaler-app/values.schema.json
+++ b/helm/cluster-autoscaler-app/values.schema.json
@@ -133,6 +133,14 @@
         "namespace": {
             "type": "string"
         },
+        "node": {
+            "type": "object",
+            "properties": {
+                "nodeSelector": {
+                    "type": "object"
+                }
+            }
+        },
         "port": {
             "type": "integer"
         },

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -64,7 +64,7 @@ balancingIgnoreLabels:
   balancing-ignore-label_3: giantswarm.io/machine-deployment
 
 # Node-level settings for the deployment
-node: 
+node:
   # sets spec.template.spec.nodeSelector for the deployment
   # Defaults (computed on k8s version in the template) should be ok for most cases running on control plane nodes, managed k8s services (e.g. EKS) need customization.
   nodeSelector: {}

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -66,8 +66,10 @@ balancingIgnoreLabels:
 # Node-level settings for the deployment
 node:
   # sets spec.template.spec.nodeSelector for the deployment
-  # Defaults (computed on k8s version in the template) should be ok for most cases running on control plane nodes, managed k8s services (e.g. EKS) need customization.
-  nodeSelector: {}
+  # The default value should be ok for most cases running on control plane nodes (it gets translated to node-role.kubernetes.io/master for k8s <v1.24.0), managed k8s services (e.g. EKS) need customization.
+  # Set it to {} to remove the nodeSelector.
+  nodeSelector: 
+    node-role.kubernetes.io/control-plane: ""
   # path to the CA bundle on the node
   caBundlePath: "/etc/ssl/certs/ca-certificates.crt"
 

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -63,6 +63,14 @@ balancingIgnoreLabels:
   balancing-ignore-label_2: vpc.amazonaws.com/eniConfig
   balancing-ignore-label_3: giantswarm.io/machine-deployment
 
+# Node-level settings for the deployment
+node: 
+  # sets spec.template.spec.nodeSelector for the deployment
+  # Defaults (computed on k8s version in the template) should be ok for most cases running on control plane nodes, managed k8s services (e.g. EKS) need customization.
+  nodeSelector: {}
+  # path to the CA bundle on the node
+  caBundlePath: "/etc/ssl/certs/ca-certificates.crt"
+
 global:
   podSecurityStandards:
     enforced: false

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -68,7 +68,7 @@ node:
   # sets spec.template.spec.nodeSelector for the deployment
   # The default value should be ok for most cases running on control plane nodes (it gets translated to node-role.kubernetes.io/master for k8s <v1.24.0), managed k8s services (e.g. EKS) need customization.
   # Set it to {} to remove the nodeSelector.
-  nodeSelector: 
+  nodeSelector:
     node-role.kubernetes.io/control-plane: ""
   # path to the CA bundle on the node
   caBundlePath: "/etc/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
This PR adds `node.nodeSelector` and `node.caBundlePath` in helm values, necessary to make the cluster-autoscaler work in EKS.

Towards https://github.com/giantswarm/giantswarm/issues/29315