### PR TITLE
Allow to configure ssl cert paths and nodeselector through helm value…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add configurable `node.nodeSelector` in values
+- Add configurable `node.caBundlePath` in values
+
 ## [1.27.3-gs4] - 2023-11-15
 
 ### Added

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -26,12 +26,14 @@ spec:
       - effect: NoSchedule
         operator: "Exists"
         key: node-role.kubernetes.io/control-plane
+      {{- if ((.Values.node).nodeSelector) }}
       nodeSelector:
-{{- if semverCompare ">=1.24.0" .Capabilities.KubeVersion.Version }}
-        node-role.kubernetes.io/control-plane: ""
-{{- else }}
-        node-role.kubernetes.io/master: ""
-{{- end }}
+        {{- if and (hasKey .Values.node.nodeSelector "node-role.kubernetes.io/control-plane") (semverCompare "<1.24.0" .Capabilities.KubeVersion.Version) }}
+        {{- toYaml (set (unset .Values.node.nodeSelector "node-role.kubernetes.io/control-plane") "node-role.kubernetes.io/master" "" ) | nindent 8 }}
+        {{- else }}
+        {{- toYaml .Values.node.nodeSelector | nindent 8 }}
+        {{- end }}
+      {{- end }}
       priorityClassName: giantswarm-critical
       containers:
         {{- if eq .Values.isManagementCluster true }}
@@ -114,4 +116,4 @@ spec:
       volumes:
         - name: ssl-certs
           hostPath:
-            path: "/etc/ssl/certs/ca-certificates.crt"
+            path: {{ .Values.node.caBundlePath }}

--- a/helm/cluster-autoscaler-app/values.schema.json
+++ b/helm/cluster-autoscaler-app/values.schema.json
@@ -128,6 +128,17 @@
         "namespace": {
             "type": "string"
         },
+        "node": {
+            "type": "object",
+            "properties": {
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "caBundlePath": {
+                    "type": "string"
+                }
+            }
+        },
         "port": {
             "type": "integer"
         },

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -62,6 +62,16 @@ balancingIgnoreLabels:
   balancing-ignore-label_2: vpc.amazonaws.com/eniConfig
   balancing-ignore-label_3: giantswarm.io/machine-deployment
 
+# Node-level settings for the deployment
+node:
+  # sets spec.template.spec.nodeSelector for the deployment
+  # The default value should be ok for most cases running on control plane nodes (it gets translated to node-role.kubernetes.io/master for k8s <v1.24.0), managed k8s services (e.g. EKS) need customization.
+  # Set it to {} to remove the nodeSelector.
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
+  # path to the CA bundle on the node
+  caBundlePath: "/etc/ssl/certs/ca-certificates.crt"
+
 global:
   podSecurityStandards:
     enforced: false


### PR DESCRIPTION
Porting changes from https://github.com/giantswarm/cluster-autoscaler-app/pull/227 to 1.27.x release branch for EKS testing.

Towards https://github.com/giantswarm/giantswarm/issues/29315