### PR TITLE
Proxy env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add possibility to use egress proxy.
+
 ## [1.27.3-gs6] - 2024-02-05
 
 ### Added

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -83,6 +83,9 @@ spec:
         {{- end }}
         {{- $proxy := deepCopy .Values.cluster.proxy |  mustMerge .Values.proxy }}
         {{- if and $proxy.noProxy $proxy.http $proxy.https }}
+        {{- if ne .Values.provider "azure" }}
+        env:
+        {{- end }}
         - name: NO_PROXY
           value: {{ $proxy.noProxy }}
         - name: no_proxy

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -81,6 +81,21 @@ spec:
         - name: ARM_VM_TYPE
           value: {{ .Values.azure.vmType }}
         {{- end }}
+        {{- $proxy := deepCopy .Values.cluster.proxy |  mustMerge .Values.proxy }}
+        {{- if and $proxy.noProxy $proxy.http $proxy.https }}
+        - name: NO_PROXY
+          value: {{ $proxy.noProxy }}
+        - name: no_proxy
+          value: {{ $proxy.noProxy }}
+        - name: HTTP_PROXY
+          value: {{ $proxy.http }}
+        - name: http_proxy
+          value: {{ $proxy.http }}
+        - name: HTTPS_PROXY
+          value: {{ $proxy.https }}
+        - name: https_proxy
+          value: {{ $proxy.https }}
+        {{- end }}
         ports:
         - name: metrics
           protocol: TCP

--- a/helm/cluster-autoscaler-app/values.schema.json
+++ b/helm/cluster-autoscaler-app/values.schema.json
@@ -32,6 +32,25 @@
                 }
             }
         },
+        "cluster": {
+            "type": "object",
+            "properties": {
+                "proxy": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": ["string","null"]
+                        },
+                        "https": {
+                            "type": ["string","null"]
+                        },
+                        "noProxy": {
+                            "type": ["string","null"]
+                        }
+                    }
+                }
+            }
+        },
         "clusterID": {
             "type": "string"
         },
@@ -121,6 +140,20 @@
         },
         "provider": {
             "type": "string"
+        },
+        "proxy": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": ["string","null"]
+                },
+                "https": {
+                    "type": ["string","null"]
+                },
+                "noProxy": {
+                    "type": ["string","null"]
+                }
+            }
         },
         "registry": {
             "type": "object",

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -112,6 +112,19 @@ registry:
   # This value is set automatically. Do not overwrite it.
   domain: gsoci.azurecr.io
 
+# set the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variable
+proxy:
+  noProxy:
+  http:
+  https:
+cluster:
+  # is getting overwritten by the top level proxy if set
+  # These values are generated via cluster-apps-operator
+  proxy:
+    noProxy:
+    http:
+    https:
+
 global:
   podSecurityStandards:
     # -- If Pod Security Standards are being used or not.


### PR DESCRIPTION
towards: https://github.com/giantswarm/giantswarm/issues/29462 and https://github.com/giantswarm/roadmap/issues/3098

on private clusters, we use kyverno to inject proxy env vars to all pods for egress to work.
Unfortunately, we can't use the same approach for pods in kube-system (design choice).

Thus we need to deal with proxy envs in this app, like we do in other kube-system apps.

this PR adds new values conformant to other apps and populated by cluster-apps-operator to add proxy envs to the pod.