### PR TITLE
Chart: Improve proxy settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Improve proxy settings. ([#249](https://github.com/giantswarm/cluster-autoscaler-app/pull/249))
+
 ## [1.27.3-gs7] - 2024-02-12
 
 ### Added

--- a/helm/cluster-autoscaler-app/README.md
+++ b/helm/cluster-autoscaler-app/README.md
@@ -1,6 +1,6 @@
 # cluster-autoscaler-app
 
-![Version: 1.27.3-gs6](https://img.shields.io/badge/Version-1.27.3--gs6-informational?style=flat-square) ![AppVersion: 1.27.3](https://img.shields.io/badge/AppVersion-1.27.3-informational?style=flat-square)
+![Version: 1.27.3-gs7](https://img.shields.io/badge/Version-1.27.3--gs7-informational?style=flat-square) ![AppVersion: 1.27.3](https://img.shields.io/badge/AppVersion-1.27.3-informational?style=flat-square)
 
 A Helm chart for the Cluster Autoscaler.
 
@@ -14,6 +14,7 @@ A Helm chart for the Cluster Autoscaler.
 | azure.managedIdentity | bool | `true` | If the VMSS instances' managed identity should be used or not. |
 | azure.subscriptionID | string | `""` | ID of the subscription the VMSSs are contained in. |
 | azure.vmType | string | `"VMSS"` | Azure VM type. |
+| cluster.proxy | object | `{"http":"","https":"","noProxy":""}` | Global proxy settings. This value is set automatically. Do not overwrite it. |
 | clusterID | string | `"sc4l3"` | Cluster ID. This value is set automatically. Do not overwrite it. |
 | configmap.balanceSimilarNodeGroups | string | `"true"` | Detect similar node groups and balance the number of nodes between them. |
 | configmap.balancingIgnoreLabels | list | `["ip","vpc.amazonaws.com/eniConfig","giantswarm.io/machine-deployment"]` | Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar. |
@@ -33,6 +34,7 @@ A Helm chart for the Cluster Autoscaler.
 | node.caBundlePath | string | `"/etc/ssl/certs/ca-certificates.crt"` | Host path of the CA bundle. |
 | node.nodeSelector | object | `{"node-role.kubernetes.io/control-plane":""}` | Node selector for the autoscaler pod. `control-plane` gets translated to `master` and vice versa depending on Kubernetes version. |
 | provider | string | `"aws"` | Provider the cluster is running on. This value is set automatically. Do not overwrite it. |
+| proxy | object | `{"http":"","https":"","noProxy":""}` | Local proxy settings. Overrides global proxy settings. This value is set automatically. Do not overwrite it. |
 | registry.domain | string | `"gsoci.azurecr.io"` | Registry host to pull images from. This value is set automatically. Do not overwrite it. |
 | resources | object | `{"limits":{"memory":"400Mi"},"requests":{"cpu":"200m","memory":"400Mi"}}` | Container resource requests and limits. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context. |

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -68,8 +68,10 @@ spec:
         {{- range $value := .Values.configmap.balancingIgnoreLabels }}
         - --balancing-ignore-label={{ $value }}
         {{- end }}
-        {{- if eq .Values.provider "azure" }}
+        {{- $_ := merge .Values.proxy .Values.cluster.proxy }}
+        {{- if or (eq .Values.provider "azure") (and .Values.proxy.http .Values.proxy.https .Values.proxy.noProxy) }}
         env:
+        {{- if eq .Values.provider "azure" }}
         {{- if and (not .Values.isManagementCluster) .Values.azure.subscriptionID }}
         - name: ARM_SUBSCRIPTION_ID
           value: {{ .Values.azure.subscriptionID }}
@@ -81,23 +83,20 @@ spec:
         - name: ARM_VM_TYPE
           value: {{ .Values.azure.vmType }}
         {{- end }}
-        {{- $proxy := deepCopy .Values.cluster.proxy |  mustMerge .Values.proxy }}
-        {{- if and $proxy.noProxy $proxy.http $proxy.https }}
-        {{- if ne .Values.provider "azure" }}
-        env:
-        {{- end }}
-        - name: NO_PROXY
-          value: {{ $proxy.noProxy }}
-        - name: no_proxy
-          value: {{ $proxy.noProxy }}
-        - name: HTTP_PROXY
-          value: {{ $proxy.http }}
+        {{- if and .Values.proxy.http .Values.proxy.https .Values.proxy.noProxy }}
         - name: http_proxy
-          value: {{ $proxy.http }}
-        - name: HTTPS_PROXY
-          value: {{ $proxy.https }}
+          value: {{ .Values.proxy.http }}
+        - name: HTTP_PROXY
+          value: {{ .Values.proxy.http }}
         - name: https_proxy
-          value: {{ $proxy.https }}
+          value: {{ .Values.proxy.https }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.proxy.https }}
+        - name: no_proxy
+          value: {{ .Values.proxy.noProxy }}
+        - name: NO_PROXY
+          value: {{ .Values.proxy.noProxy }}
+        {{- end }}
         {{- end }}
         ports:
         - name: metrics

--- a/helm/cluster-autoscaler-app/values.schema.json
+++ b/helm/cluster-autoscaler-app/values.schema.json
@@ -39,13 +39,13 @@
                     "type": "object",
                     "properties": {
                         "http": {
-                            "type": ["string","null"]
+                            "type": "string"
                         },
                         "https": {
-                            "type": ["string","null"]
+                            "type": "string"
                         },
                         "noProxy": {
-                            "type": ["string","null"]
+                            "type": "string"
                         }
                     }
                 }
@@ -145,13 +145,13 @@
             "type": "object",
             "properties": {
                 "http": {
-                    "type": ["string","null"]
+                    "type": "string"
                 },
                 "https": {
-                    "type": ["string","null"]
+                    "type": "string"
                 },
                 "noProxy": {
-                    "type": ["string","null"]
+                    "type": "string"
                 }
             }
         },

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -112,18 +112,20 @@ registry:
   # This value is set automatically. Do not overwrite it.
   domain: gsoci.azurecr.io
 
-# set the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variable
-proxy:
-  noProxy:
-  http:
-  https:
 cluster:
-  # is getting overwritten by the top level proxy if set
-  # These values are generated via cluster-apps-operator
+  # -- Global proxy settings.
+  # This value is set automatically. Do not overwrite it.
   proxy:
-    noProxy:
-    http:
-    https:
+    http: ""
+    https: ""
+    noProxy: ""
+
+# -- Local proxy settings. Overrides global proxy settings.
+# This value is set automatically. Do not overwrite it.
+proxy:
+  http: ""
+  https: ""
+  noProxy: ""
 
 global:
   podSecurityStandards:


### PR DESCRIPTION
- Improved the templating of the proxy environment variables. `merge` manipulates the destination dictionary anyway, so `deepCopy` and `$proxy` variable are useless.
- Set empty strings as default values and made the docs getting picked up by `helm-docs`.
- Updated the `README.md` to include the latest release and documentation for the added values.