### PR TITLE
Add node startup taints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add node startup taints. ([#274](https://github.com/giantswarm/cluster-autoscaler-app/pull/274)) 
+
 ## [1.27.3-gs9] - 2024-05-20
 
 ### Changed

--- a/helm/cluster-autoscaler-app/templates/deployment.yaml
+++ b/helm/cluster-autoscaler-app/templates/deployment.yaml
@@ -65,6 +65,9 @@ spec:
         - --scale-down-utilization-threshold={{ .Values.configmap.scaleDownUtilizationThreshold }}
         - --scale-down-unneeded-time={{ .Values.configmap.scaleDownUnneededTime }}
         - --balance-similar-node-groups={{ .Values.configmap.balanceSimilarNodeGroups }}
+        {{- range $value := .Values.configmap.nodeStartupTaints }}
+        - --ignore-taint={{ $value }}
+        {{- end }}
         {{- range $value := .Values.configmap.balancingIgnoreLabels }}
         - --balancing-ignore-label={{ $value }}
         {{- end }}

--- a/helm/cluster-autoscaler-app/values.schema.json
+++ b/helm/cluster-autoscaler-app/values.schema.json
@@ -72,6 +72,12 @@
                 "newPodScaleUpDelay": {
                     "type": "string"
                 },
+                "nodeStartupTaints": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "scaleDownUnneededTime": {
                     "type": "string"
                 },

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -60,6 +60,12 @@ configmap:
   - vpc.amazonaws.com/eniConfig
   - giantswarm.io/machine-deployment
 
+  # -- Taints that are added to new nodes during node initialization.
+  # Cluster Autoscaler treats nodes tainted with startup taints as unready, but taken into account during scale up logic, assuming they will become ready shortly.
+  # See: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-treat-nodes-with-statusstartupignore-taints
+  nodeStartupTaints:
+  - node.cluster.x-k8s.io/uninitialized
+
 azure:
   # -- ID of the subscription the VMSSs are contained in.
   subscriptionID: ""


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3554

We are currently setting the taint `node.cluster.x-k8s.io/uninitialized` with the effect NoSchedule for new nodes, and when scaling up that causes cluster-autoscaler to add new nodes until one has finished initializing, only to remove those additional nodes after the scaledown period (5 minutes).

This PR adds the option to set node startup taints in the cluster autoscaler:
https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-treat-nodes-with-statusstartupignore-taints

For cluster-autoscaler <1.29.0 we need to set `--ignore-taint` (which has the same behaviour of `--startup-taint` in newer versions: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.29.0).

