### PR TITLE
Update Kyverno PolicyExceptions to v2beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update `PolicyExceptions` apiVersion to `v2beta1`. ([#282](https://github.com/giantswarm/cluster-autoscaler-app/pull/282))
+
 ## [1.29.3-gs1] - 2024-07-17
 
 ### Changed

--- a/helm/cluster-autoscaler-app/templates/policyexception.yaml
+++ b/helm/cluster-autoscaler-app/templates/policyexception.yaml
@@ -1,5 +1,5 @@
-{{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" }}
-apiVersion: kyverno.io/v2alpha1
+{{- if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" }}
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ include "cluster-autoscaler.fullname" . }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30726

The current `v2alpha1` apiVersion is getting deprecated and removed in a future Kyverno version. 

`v2beta1` should be already available in all clusters.