### PR TITLE
Support additionalLabels on PodMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Support adding additional labels to the `PodMonitor` resource via the `podMonitor.additionalLabels` value.
+
 ## [1.30.4-gs1] - 2025-03-17
 
 ### Changed
@@ -39,13 +43,13 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Update to upstream 1.28.5. ([#276](https://github.com/giantswarm/cluster-autoscaler-app/pull/276)) 
+- Update to upstream 1.28.5. ([#276](https://github.com/giantswarm/cluster-autoscaler-app/pull/276))
 
 ## [1.27.3-gs10] - 2024-07-08
 
 ### Changed
 
-- Add node startup taints. ([#274](https://github.com/giantswarm/cluster-autoscaler-app/pull/274)) 
+- Add node startup taints. ([#274](https://github.com/giantswarm/cluster-autoscaler-app/pull/274))
 
 ## [1.27.3-gs9] - 2024-05-20
 

--- a/helm/cluster-autoscaler-app/README.md
+++ b/helm/cluster-autoscaler-app/README.md
@@ -34,6 +34,7 @@ A Helm chart for the Cluster Autoscaler.
 | managementCluster | string | `"sc4l3"` | Name of the management cluster this chart is installed on. This value is set automatically. Do not overwrite it. |
 | node.caBundlePath | string | `"/etc/ssl/certs/ca-certificates.crt"` | Host path of the CA bundle. |
 | node.nodeSelector | object | `{"node-role.kubernetes.io/control-plane":""}` | Node selector for the autoscaler pod. `control-plane` gets translated to `master` and vice versa depending on Kubernetes version. |
+| podMonitor.additionalLabels | object | `{}` | Add extra labels to the PodMonitor resource |
 | provider | string | `"aws"` | Provider the cluster is running on. This value is set automatically. Do not overwrite it. |
 | proxy | object | `{"http":"","https":"","noProxy":""}` | Local proxy settings. Overrides global proxy settings. This value is set automatically. Do not overwrite it. |
 | registry.domain | string | `"gsoci.azurecr.io"` | Registry host to pull images from. This value is set automatically. Do not overwrite it. |

--- a/helm/cluster-autoscaler-app/templates/podmonitor.yaml
+++ b/helm/cluster-autoscaler-app/templates/podmonitor.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cluster-autoscaler.labels" . | nindent 4 }}
+    {{- with .Values.podMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm/cluster-autoscaler-app/values.schema.json
+++ b/helm/cluster-autoscaler-app/values.schema.json
@@ -144,6 +144,14 @@
                 }
             }
         },
+        "podMonitor": {
+            "type": "object",
+            "properties": {
+                "additionalLabels": {
+                    "type": "object"
+                }
+            }
+        },
         "provider": {
             "type": "string"
         },

--- a/helm/cluster-autoscaler-app/values.yaml
+++ b/helm/cluster-autoscaler-app/values.yaml
@@ -96,6 +96,10 @@ autoscaling:
     cpu: 50m
     memory: 100Mi
 
+podMonitor:
+  # -- Add extra labels to the PodMonitor resource
+  additionalLabels: {}
+
 # Below are configuration values that you should not overwrite or set yourself.
 
 # -- Provider the cluster is running on.


### PR DESCRIPTION
This PR adds a new `.podMonitor.additionalLabels` property to the values file that allows adding extra labels to the created PodMonitor resource. 