### PR TITLE
fix(rbac): Grant access to `resourceslices.resource.k8s.io`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- RBAC: Grant access to `resourceslices.resource.k8s.io`.
+
 ## [1.35.0-1] - 2026-05-27
 
 ### Changed

--- a/helm/cluster-autoscaler-app/templates/clusterrole.yaml
+++ b/helm/cluster-autoscaler-app/templates/clusterrole.yaml
@@ -136,6 +136,13 @@ rules:
   verbs:
   - get
   - update
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceslices
+  verbs:
+  - list
+  - watch
 {{- if not .Values.global.podSecurityStandards.enforced }}
 - apiGroups:
   - extensions


### PR DESCRIPTION
```
E0608 09:41:28.250030       1 reflector.go:204] "Failed to watch" err="failed to list *v1.ResourceSlice: resourceslices.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"resourceslices\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.ResourceSlice"
```