### PR TITLE
fix(templates): Move PolicyException to `giantswarm` namespace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Templates: Move PolicyException to `giantswarm` namespace.
+
 ## [2.0.1] - 2026-06-15
 
 ### Changed

--- a/helm/cluster-autoscaler-app/templates/policyexception.yaml
+++ b/helm/cluster-autoscaler-app/templates/policyexception.yaml
@@ -1,9 +1,8 @@
-{{- if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" }}
 apiVersion: kyverno.io/v2
 kind: PolicyException
 metadata:
   name: {{ include "cluster-autoscaler.fullname" . }}
-  namespace: policy-exceptions
+  namespace: giantswarm
   labels:
     {{- include "cluster-autoscaler.labels" . | nindent 4 }}
   annotations:
@@ -29,4 +28,3 @@ spec:
     ruleNames:
     - restricted-volumes
     - autogen-restricted-volumes
-{{- end }}


### PR DESCRIPTION
This speeds up cluster creation since the `policy-exceptions` namespace gets created way later.

Also I removed the capability gate as this could prevent the PolicyException to be installed at all and we'd rather want to block installation than having it missing.